### PR TITLE
move CardScrollArea into own component

### DIFF
--- a/web_frontend/src/components/CardScrollArea.tsx
+++ b/web_frontend/src/components/CardScrollArea.tsx
@@ -1,0 +1,59 @@
+import { ScrollArea } from "@mantine/core";
+import { Collapse } from "@material-ui/core";
+import { TransitionGroup } from "react-transition-group";
+import ExplicitCard from "./ExplicitCard";
+import ReferenceCard from "./ReferenceCard";
+import {
+  entitiesState,
+  isExplicitListeningState,
+  selectedCardIdState,
+} from "../recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
+
+const CardScrollArea = () => {
+  const entities = useRecoilValue(entitiesState);
+  const isExplicitListening = useRecoilValue(isExplicitListeningState);
+  const [selectedCardId, setSelectedCardId] =
+    useRecoilState(selectedCardIdState);
+
+  return (
+    <ScrollArea scrollHideDelay={100} h="100%" type="never">
+      <TransitionGroup>
+        {isExplicitListening && (
+          <Collapse timeout={800}>
+            <ExplicitCard />
+          </Collapse>
+        )}
+        {entities
+          .filter((e) => {
+            if (e == null || e == undefined) {
+              console.log("NULL ENTITY FOUND");
+              return false;
+            }
+            return true;
+          })
+          .slice(0)
+          .reverse()
+          .map((entity, i) => (
+            <Collapse key={`entity-${entity.uuid}`} timeout={800}>
+              <ReferenceCard
+                entity={entity}
+                selected={
+                  selectedCardId === entity.uuid && !isExplicitListening
+                }
+                onClick={() => {
+                  setSelectedCardId(
+                    entity.uuid === selectedCardId ? undefined : entity.uuid
+                  );
+                }}
+                large={i === 0 && !isExplicitListening}
+                pointer={entity.url !== undefined}
+              />
+            </Collapse>
+          ))}
+      </TransitionGroup>
+    </ScrollArea>
+  );
+};
+
+export default CardScrollArea;

--- a/web_frontend/src/components/ExplorePane.tsx
+++ b/web_frontend/src/components/ExplorePane.tsx
@@ -1,18 +1,16 @@
-import {
-  ActionIcon,
-  Skeleton,
-  Tooltip,
-  Text,
-} from "@mantine/core";
+import { ActionIcon, Skeleton, Tooltip, Text } from "@mantine/core";
 import { IconArrowUp } from "@tabler/icons-react";
+import { explorePaneUrlValue } from "../recoil";
+import { useRecoilValue } from "recoil";
 
 interface ExplorePaneProps {
-  viewMoreUrl: string | undefined;
   loading: boolean;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const ExplorePane = ({ viewMoreUrl, loading, setLoading }: ExplorePaneProps) => {
+const ExplorePane = ({ loading, setLoading }: ExplorePaneProps) => {
+  const viewMoreUrl = useRecoilValue(explorePaneUrlValue);
+
   const handleLoad = () => {
     setLoading(false);
   };

--- a/web_frontend/src/recoil.ts
+++ b/web_frontend/src/recoil.ts
@@ -1,4 +1,4 @@
-import { atom } from "recoil";
+import { atom, selector } from "recoil";
 import { Entity, Insight } from "./types";
 
 export const isExplicitListeningState = atom<boolean>({
@@ -23,4 +23,32 @@ export const entitiesState = atom<Entity[]>({ key: "entities", default: [] });
 export const explicitInsightsState = atom<Insight[]>({
   key: "explicitInsights",
   default: [],
+});
+
+export const selectedCardIdState = atom<string | undefined>({
+  key: "selectedCardId",
+  default: undefined,
+});
+
+export const selectedEntityValue = selector<Entity | undefined>({
+  key: "selectedEntity",
+  get: ({ get }) => {
+    return get(entitiesState).find(
+      (entity) => entity.uuid === get(selectedCardIdState)
+    );
+  },
+});
+
+export const explorePaneUrlValue = selector<string | undefined>({
+  key: "explorePaneUrl",
+  get: ({ get }) => {
+    return get(selectedEntityValue)?.url;
+  },
+});
+
+export const showExplorePaneValue = selector<boolean>({
+  key: "showExplorePane",
+  get: ({ get }) => {
+    return get(explorePaneUrlValue) !== undefined;
+  },
 });


### PR DESCRIPTION
Small refactor to move CardScrollArea into its own component and move some more state into recoil. 

Everything should work the same as before. Also, I changed the "expand explore pane" button to try to open up the topmost card if it has a url. If not, the button disabled. After thinking more about it I'm not completely sure if it makes sense to have an "expand" button, but it's probably fine to keep for now.