### PR TITLE
Definer improvements dec

### DIFF
--- a/server/agents/proactive_meta_agent.py
+++ b/server/agents/proactive_meta_agent.py
@@ -69,7 +69,8 @@ def run_proactive_meta_agent_and_experts(conversation_context: str, insights_his
     #parse insights history into a dict of agent_name: [agent_insights] so expert agent won't repeat the same insights
     insights_history_dict = defaultdict(list)
     for insight in insights_history:
-        insights_history_dict[insight["agent_name"]].append(insight["insight"])
+        insights_history_dict[insight["agent_name"]].append(
+            insight["agent_insight"])
 
     # print("insights_history_dict", insights_history_dict)
 

--- a/server/agents/search_tool_for_agents.py
+++ b/server/agents/search_tool_for_agents.py
@@ -415,7 +415,7 @@ async def search_url_for_entity_async(query: str):
             search_type="search",
         ))
 
-        image_search_task = None if "definition" in query else asyncio.create_task(serper_search_async(
+        image_search_task = asyncio.create_task(serper_search_async(
             search_term=query,
             gl=gl,
             hl=hl,
@@ -424,9 +424,7 @@ async def search_url_for_entity_async(query: str):
             search_type="images",
         ))
 
-        tasks = [search_task]
-        if image_search_task:
-            tasks.append(image_search_task)
+        tasks = [search_task, image_search_task]
 
         search_results, image_results = await asyncio.gather(*tasks)
         

--- a/server/agents/search_tool_for_agents.py
+++ b/server/agents/search_tool_for_agents.py
@@ -368,40 +368,71 @@ async def asearch_google_knowledge_graph(
     
     return response
 
+import requests
+
+def can_embed_url(url: str):
+    response = requests.head(url)
+
+    # Check the headers for 'X-Frame-Options' or 'Content-Security-Policy'
+    x_frame_options = response.headers.get('X-Frame-Options')
+    csp = response.headers.get('Content-Security-Policy')
+
+    return not (x_frame_options or ('frame-ancestors' in csp if csp else False))
 
 # definer url search tool
-def extract_entity_url_and_image(results: dict):
+def extract_entity_url_and_image(search_results: dict, image_results: dict):
     # Only get the first top url and image_url
     res = {}
-    if results.get("knowledgeGraph"):
-        result = results.get("knowledgeGraph", {})
+    if search_results.get("knowledgeGraph"):
+        result = search_results.get("knowledgeGraph", {})
         if result.get("descriptionSource") == "Wikipedia":
             ref_url = result.get("descriptionLink")
             res["url"] = ref_url
-        if result.get("imageUrl"):
-            image_url = result.get("imageUrl")
-            res["image_url"] = image_url
-    if "url" in res and "image_url" in res:
-        return res
 
-    for result in results[result_key_for_type[search_type]][:k]:
-        if "url" not in res and result.get("link"):
+    for result in search_results[result_key_for_type["search"]][:k]:
+        if "url" not in res and result.get("link") and can_embed_url(result.get("link")):
             res["url"] = result.get("link")
+            break
+
+    if image_results is None:
+        return res
+    
+    for result in image_results[result_key_for_type["images"]][:k]:
         if "image_url" not in res and result.get("imageUrl"):
             res["image_url"] = result.get("imageUrl")
+            break
 
-        if "url" in res and "image_url" in res:
-            return res
     return res
 
-
 async def search_url_for_entity_async(query: str):
-    results = await serper_search_async(
-        search_term=query,
-        gl=gl,
-        hl=hl,
-        num=k,
-        tbs=tbs,
-        search_type=search_type,
-    )
-    return extract_entity_url_and_image(results)
+    async def inner_search(query:str): 
+        search_task = asyncio.create_task(serper_search_async(
+            search_term=query,
+            gl=gl,
+            hl=hl,
+            num=k,
+            tbs=tbs,
+            search_type="search",
+        ))
+
+        image_search_task = None if "definition" in query else asyncio.create_task(serper_search_async(
+            search_term=query,
+            gl=gl,
+            hl=hl,
+            num=k,
+            tbs=tbs,
+            search_type="images",
+        ))
+
+        tasks = [search_task]
+        if image_search_task:
+            tasks.append(image_search_task)
+
+        search_results, image_results = await asyncio.gather(*tasks)
+        
+        return extract_entity_url_and_image(search_results, image_results)
+    
+    res = await inner_search(query)
+    if "url" not in res:
+        res = await inner_search(query + " wiki") # fallback search using wiki
+    return res

--- a/server/tests/experiment-definer.ipynb
+++ b/server/tests/experiment-definer.ipynb
@@ -34,22 +34,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Processing episode_158_large...\n",
-      "Processing episode_255_large...\n",
-      "Processing episode_108_large...\n",
-      "Processing episode_145_large...\n",
-      "Processing episode_269_large...\n",
-      "Processing episode_276_large...\n",
-      "Processing episode_251_large...\n",
-      "Processing episode_167_large...\n",
-      "Processing episode_270_large...\n",
-      "Processing episode_095_large...\n"
+      "Processing episode_069_large...\n",
+      "Processing episode_305_large...\n",
+      "Processing episode_166_large...\n",
+      "Processing episode_023_large...\n",
+      "Processing episode_095_large...\n",
+      "Processing episode_238_large...\n",
+      "Processing episode_058_large...\n",
+      "Processing episode_239_large...\n",
+      "Processing episode_253_large...\n",
+      "Processing episode_006_large...\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "\" Won't selection result in a few pockets of interesting complexities? I mean, yeah, if we ran Earth over again, over and over and over, you're saying it's going to come up with, there's not going to be elephants every time? Yeah, I don't think so. I think that there will be similarities., And I think we don't know enough about how selection globally works. But it might be that the emergence of elephants was wired into the history of Earth in some way, like the gravitational force, how evolution was going, Cambrian explosions, blah, blah, blah, the emergence of mammals. But I just don't know enough about the contingency,, the variability. All I do know is you count the number of bits of information required to make an elephant and think about the causal chain that provide the lineage of elephants going all the way back to Luca, there's a huge scope for divergence. Yeah, but just like you said, with chemistry and selection,, the things that result in self replicating chemistry and self replicating organisms, those are extremely unlikely, as you're saying. But once they're successful, they multiply. So it might be a tiny subset of all things, that are possible in the universe, chemically speaking, it might be a very tiny subset is actually successful at creating elephants. Or elephant like or slash human like creatures. Well, there's two different questions here. The first one, if we were to reset Earth and to start again. The different phases, sorry to keep interrupting. Yeah, no, if we restart Earth and start again, say we could go back to the beginning and do the experiment or have a number of Earths,\\n how similar would biology be? I would say that there would be broad similarities, but the emergence of mammals is not a given unless we're gonna throw an asteroid at each planet at each time and try and faithfully reproduce what happened. Then there's the other thing about when you go to another Earth like planet elsewhere, maybe there's a different ratio, particular elements,\""
+       "\" The art of running such a lab is that there are strategic priorities for the company. And there are areas where we do want to invest and pressing problems. And so it's a little bit of a trickle down and filter up meets in the middle. And so you don't tell people you have to do X, but you say X would be particularly appreciated this year. And then people reinterpret, X through the filter of things they want to do and they're interested in. And miraculously, it usually comes together very well. One thing that really helps is Adobe has a really broad portfolio of products. So if we have a good idea, there's usually a product team that is intrigued or interested. So it means we don't have to qualify things too much ahead of time., Once in a while, the product teams sponsor extra intern, because they have a particular problem that they really care about, in which case it's a little bit more, we really need one of these. And then we sort of say, great, I get an extra intern, we find an intern who thinks that's a great problem. But that's not the typical model. That's sort of the icing on the cake as far as the budget is concerned. And all of the above end up being important. It's really hard to predict, at the beginning of the summer, which we all have high hopes of all of the intern projects, but ultimately, some of them pay off and some of them sort of are a nice paper, but don't turn into a feature. Others turn out not to be as novel as we thought, but they'd be a great feature, but not a paper. And then others, we make a little bit of progress and we realize how much we don't know. And maybe we revisit that problem several years in a row until it,, finally we have a breakthrough and then it becomes more on track to impact a product. Jumping back to a big overall view of Adobe research, what are you looking forward to in 2019 and beyond? What is, you mentioned there's a giant suite of products, a giant suite of ideas, new interns, a large team of researchers.\\n What do you think the future holds? In terms of the technological breakthroughs? Technological breakthroughs, especially ones that will make it into product, will get to impact the world. So I think the creative or the analytics assistants that we talked about where they're constantly trying to figure out what you're trying to do and how can they be helpful and make useful suggestions is a really hot topic. And it's very unpredictable as to when\""
       ]
      },
      "execution_count": 2,
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,47 +90,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
     "proactive_rare_word_agent_prompt_blueprint = \"\"\"\n",
-    "# Objective: \n",
-    "Identify \"Rare Entities\" in a conversation transcript. These include rare words, phrases, jargons, adages, people, places, organizations, events etc that are not well known to the average high schooler, in accordance to current trends. We are using a really lousy transcribing service, so words are often mispelt, but you can autocorrect and piece together implied entities that are described in the conversation context but not explicitly mentioned, your vast knowledge base to derive the \"Rare Entity\" originally mentioned by the user. If you feel the need to search for the entity, then it is most likely mistranscribed.\n",
+    "# Objective\n",
+    "Your role is to identify and define \"Rare Entities\" in a conversation transcript. Types of \"Rare Entities\" include rare words, phrases, jargons, adages, people, places, organizations, events etc that are not well known to the average high schooler, in accordance to current trends. You can also intelligently detect entities that are described in the conversation but not explicitly mentioned.\n",
     "\n",
-    "# Criteria for Rare Entities in order of importance:\n",
+    "# Criteria for Rare Entities in order of importance\n",
     "1. Rarity: Select entities that are unlikely for an average high schooler to know. Well known entities are like Fortune 500 organizations, worldwide-known events, popular locations, and entities popularized by recent news or events such as \"COVID-19\", \"Bitcoin\", or \"Generative AI\".\n",
     "2. Utility: Definition should help a user understand the conversation better and achieve their goals.\n",
     "3. No Redundancy: Exclude definitions if already defined in the conversation.\n",
-    "4. Complexity: Choose terms with non-obvious meanings, such as \"Butterfly Effect\" and not \"Electric Car\".\n",
+    "4. Complexity: Choose terms with non-obvious meanings, such as \"Butterfly Effect\" but not \"Electric Car\".\n",
     "5. Definability: Must be clearly and succinctly definable in under 10 words.\n",
-    "6. Searchability: Likely to have a specific and valid reference source: Wikipedia page, dictionary entry etc.\n",
+    "6. Existance: Don't select entities if you have no knowledge of them\n",
     "\n",
     "# Conversation Transcript:\n",
     "<Transcript start>{conversation_context}<Transcript end>\n",
     "\n",
     "# Output Guidelines:\n",
-    "Output an array:\n",
-    "entities: [{{ name: string, definition: string, ekg_search_keyword: string }}], where definition is concise (< 12 words), and ekg_search_keyword as the best search keyword for the Google Knowledge Graph.  \n",
+    "Output an array (ONLY OUTPUT THIS) of the entities you identified using the following template: `[{{ name: string, definition: string, search_keyword: string }}]`\n",
+    "\n",
+    "- name is the entity name shown to the user, if it is mistranscribed, autocorrect it, otherwise use the name quoted from the conversation\n",
+    "- definition is concise (< 12 words)\n",
+    "- search_keyword as the best Internet search keywords to find the entity, add entity type defined above for better searchability\n",
+    "- it's OK to output an empty array - most of the time, the array will be empty, only include items if the fit all the requirements\n",
     "\n",
     "## Additional Guidelines:\n",
-    "- Entity names should be quoted from the conversation, so the output definitions can be referenced back to the conversation, unless they are transcribed wrongly, then use the official name.\n",
-    "- For the search keyword, use complete, official and context relevant keyword(s) to search for that entity. You might need to autocomplete entity names or use their official names or add additional context keywords to help with searchability, especially if the entity is ambiguous or has multiple meanings. For rare words, include \"definition\" in the search keyword.\n",
+    "- Do not define entities you yourself are not familiar with, you can try to piece together the implied entity, but if you are not 90% confident, skip it.\n",
+    "- For the search keyword, use complete, official and context relevant keyword(s) to search for that entity. You might need to autocomplete entity names or use their official names or add additional context keywords (like the type of entity) to help with searchability, especially if the entity is ambiguous or has multiple meanings. Additionally, for rare words, add \"definition\" to the search keyword.\n",
     "- Definitions should use simple language to be easily understood.\n",
     "- Select entities whose definitions you are very confident about, otherwise skip them.\n",
-    "- Multiple entities can be detected from one phrase, for example, \"The Lugubrious Game\" can be defined as a painting, and the rare word \"lugubrious\" is also worth defining.\n",
-    "- Limit results to 4 or less entities, prioritize rarity.\n",
+    "- Multiple entities can be detected from one phrase, for example, \"The Lugubrious Game\" can be defined as a painting (iff the entire term \"the lugubrious game\" is mentioned), and the rare word \"lugubrious\" is also worth defining.\n",
+    "- Limit results to {number_of_definitions} entities, prioritize rarity.\n",
     "- Examples:\n",
-    "    - Completing incomplete name example: If the conversation talks about \"Balmer\" and \"Microsoft\", the keyword is \"Steve Balmer\", but the entity name would be \"Balmer\" because that is the name quoted from the conversation.\n",
-    "    - Replacing unofficial name example: If the conversation talks about \"Clay Institute\", the keyword is \"Clay Mathematics Institute\" since that is the official name, but the entity name would be \"Clay Institute\" because that is the name quoted from the conversation.\n",
-    "    - Adding context example: If the conversation talks about \"Theory of everything\", the keyword needs context keywords such as \"Theory of everything (concept)\", because there is a popular movie with the same name. \n",
+    "    - Completing incomplete name example: If the conversation talks about \"Balmer\" and \"Microsoft\", the keyword is \"Steve Balmer + person\", and the name would be \"Steve Balmer\" because it is complete.\n",
+    "    - Replacing unofficial name example: If the conversation talks about \"Clay Institute\", the keyword is \"Clay Mathematics Institute + organization\" since that is the official name, but the entity name would be \"Clay Institute\" because that is the name quoted from the conversation.\n",
+    "    - Adding context example: If the conversation talks about \"Theory of everything\", the keyword needs context keywords such as \"Theory of everything + concept\", because there is a popular movie with the same name. \n",
+    "    - Inferring transcript errors example: If the conversation mentions \"Coleman Sachs\" in the context of finance, you can infer it was supposed to be \"Goldman Sachs\", so you autocorrect and define it as \"Goldman Sachs\" and give its definition.\n",
     "\n",
     "## Recent Definitions:\n",
     "These have already been defined so don't define them again:\n",
     "{definitions_history}\n",
     "\n",
     "## Example Output:\n",
-    "entities: [{{ name: \"Moore's Law\", definition: \"Computing power doubles every ~2 yrs\", ekg_search_key: \"Moore's Law\" }}, {{ name: \"80/20 Rule\", definition: \"Productivity concept; Majority of results come from few causes\", ekg_search_key: \"Pareto Principle\" }}]\n",
+    "entities: [{{ name: \"80/20 Rule\", definition: \"Productivity concept; Majority of results come from few causes\", search_keyword: \"80/20 Rule + concept\" }}]\n",
     "\n",
     "{format_instructions} \n",
     "If no relevant entities are identified, output empty arrays.\n",
@@ -139,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,8 +181,8 @@
     "    definition: str = Field(\n",
     "        description=\"entity definition\",\n",
     "    )\n",
-    "    ekg_search_keyword: str = Field(\n",
-    "        description=\"keyword to search for entity on Google Enterprise Knowledge Graph\",\n",
+    "    search_keyword: str = Field(\n",
+    "        description=\"keyword to search for entity on the Internet\",\n",
     "    )\n",
     "\n",
     "class ConversationEntities(BaseModel):\n",
@@ -205,7 +210,8 @@
     "            \"definitions_history\",\n",
     "        ],\n",
     "        partial_variables={\n",
-    "            \"format_instructions\": proactive_rare_word_agent_query_parser.get_format_instructions()\n",
+    "            \"format_instructions\": proactive_rare_word_agent_query_parser.get_format_instructions(),\n",
+    "            \"number_of_definitions\": 3,\n",
     "        },\n",
     "    )\n",
     "\n",
@@ -233,13 +239,14 @@
     "            response.content\n",
     "        )\n",
     "        return res\n",
-    "    except OutputParserException:\n",
+    "    except OutputParserException as e:\n",
+    "        print(\"Error parsing output\" , e)\n",
     "        return None"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -247,36 +254,46 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "In the realm of artificial intelligence and big data, several key players stand out with their innovative contributions. Hugging Fase, a leader in machine learning models. Another major entity, OpenYI, has revolutionized language models. We now have the largest LLMs ever such as the Falkon LLM model\n",
+      "In the realm of artificial intelligence and big data, several key players stand out with their innovative contributions. Hugging Fase, a leader in machine learning models. Another major entity, OpenYI, has revolutionized language models. We now have the largest LLMs ever such as the Falcon LLM model\n",
       "```json\n",
       "{\n",
       "  \"entities\": [\n",
       "    {\n",
       "      \"name\": \"Hugging Face\",\n",
-      "      \"definition\": \"AI company specializing in NLP\",\n",
-      "      \"ekg_search_keyword\": \"Hugging Face\"\n",
+      "      \"definition\": \"AI company specializing in natural language processing\",\n",
+      "      \"search_keyword\": \"Hugging Face + AI company\"\n",
       "    },\n",
       "    {\n",
       "      \"name\": \"OpenAI\",\n",
-      "      \"definition\": \"AI research laboratory\",\n",
-      "      \"ekg_search_keyword\": \"OpenAI\"\n",
+      "      \"definition\": \"AI research lab, creators of GPT models\",\n",
+      "      \"search_keyword\": \"OpenAI + AI research lab\"\n",
       "    },\n",
       "    {\n",
       "      \"name\": \"Falcon LLM model\",\n",
-      "      \"definition\": \"Large language machine learning model\",\n",
-      "      \"ekg_search_keyword\": \"Falcon LLM model\"\n",
+      "      \"definition\": \"A large language model for AI applications\",\n",
+      "      \"search_keyword\": \"Falcon LLM model + AI\"\n",
       "    }\n",
       "  ]\n",
       "}\n",
       "```\n",
-      "proactive_rare_word_agent_response entities=[Entity(name='Hugging Face', definition='AI company specializing in NLP', ekg_search_keyword='Hugging Face'), Entity(name='OpenAI', definition='AI research laboratory', ekg_search_keyword='OpenAI'), Entity(name='Falcon LLM model', definition='Large language machine learning model', ekg_search_keyword='Falcon LLM model')]\n"
+      "proactive_rare_word_agent_response entities=[Entity(name='Hugging Face', definition='AI company specializing in natural language processing', search_keyword='Hugging Face + AI company'), Entity(name='OpenAI', definition='AI research lab, creators of GPT models', search_keyword='OpenAI + AI research lab'), Entity(name='Falcon LLM model', definition='A large language model for AI applications', search_keyword='Falcon LLM model + AI')]\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ConversationEntities(entities=[Entity(name='Hugging Face', definition='AI company specializing in natural language processing', search_keyword='Hugging Face + AI company'), Entity(name='OpenAI', definition='AI research lab, creators of GPT models', search_keyword='OpenAI + AI research lab'), Entity(name='Falcon LLM model', definition='A large language model for AI applications', search_keyword='Falcon LLM model + AI')])"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# test_transcript = generate_test_input()\n",
     "test_transcript = \"\"\"\n",
-    "In the realm of artificial intelligence and big data, several key players stand out with their innovative contributions. Hugging Fase, a leader in machine learning models. Another major entity, OpenYI, has revolutionized language models. We now have the largest LLMs ever such as the Falkon LLM model\"\"\"\n",
+    "In the realm of artificial intelligence and big data, several key players stand out with their innovative contributions. Hugging Fase, a leader in machine learning models. Another major entity, OpenYI, has revolutionized language models. We now have the largest LLMs ever such as the Falcon LLM model\"\"\"\n",
     "print(test_transcript)\n",
     "res = run_proactive_rare_word_agent_and_definer(test_transcript, [])\n",
     "res"
@@ -292,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +324,7 @@
     "tbs = None\n",
     "num_sentences = 7\n",
     "serper_api_key=os.environ.get(\"SERPER_API_KEY\")\n",
-    "search_type: Literal[\"news\", \"search\", \"places\", \"images\"] = \"search\"\n",
+    "search_type: Literal[\"news\", \"search\", \"places\", \"images\"] = \"images\"\n",
     "result_key_for_type = {\n",
     "        \"news\": \"news\",\n",
     "        \"places\": \"places\",\n",
@@ -376,51 +393,76 @@
     "        return [\"No good Google Search Result was found\"]\n",
     "    return snippets\n",
     "\n",
-    "def extract_entity_url_and_image(results: dict):\n",
-    "    print(results)\n",
-    "    res = {}\n",
-    "    if results.get(\"knowledgeGraph\"):\n",
-    "        res[\"url\"] = results.get(\"knowledgeGraph\", {}).get(\"descriptionLink\")\n",
-    "        res[\"imageUrl\"] = results.get(\"knowledgeGraph\", {}).get(\"imageUrl\")\n",
+    "import requests\n",
     "\n",
-    "    for result in results[result_key_for_type[search_type]][:k]:\n",
-    "        if result.get(\"link\"):\n",
+    "def can_embed_url(url: str):\n",
+    "    response = requests.head(url)\n",
+    "\n",
+    "    # Check the headers for 'X-Frame-Options' or 'Content-Security-Policy'\n",
+    "    x_frame_options = response.headers.get('X-Frame-Options')\n",
+    "    csp = response.headers.get('Content-Security-Policy')\n",
+    "\n",
+    "    return x_frame_options or ('frame-ancestors' in csp if csp else False)\n",
+    "\n",
+    "def extract_entity_url_and_image(search_results: dict, image_results: dict):\n",
+    "    # Only get the first top url and image_url\n",
+    "    res = {}\n",
+    "    if search_results.get(\"knowledgeGraph\"):\n",
+    "        result = search_results.get(\"knowledgeGraph\", {})\n",
+    "        if result.get(\"descriptionSource\") == \"Wikipedia\":\n",
+    "            ref_url = result.get(\"descriptionLink\")\n",
+    "            res[\"url\"] = ref_url\n",
+    "\n",
+    "    for result in search_results[result_key_for_type[\"search\"]][:k]:\n",
+    "        if \"url\" not in res and result.get(\"link\") and can_embed_url(result.get(\"link\")):\n",
     "            res[\"url\"] = result.get(\"link\")\n",
+    "            break\n",
+    "\n",
+    "    if image_results is None:\n",
+    "        return res\n",
     "    \n",
+    "    for result in image_results[result_key_for_type[\"images\"]][:k]:\n",
+    "        if \"image_url\" not in res and result.get(\"imageUrl\"):\n",
+    "            res[\"image_url\"] = result.get(\"imageUrl\")\n",
+    "            break\n",
+    "\n",
     "    return res\n",
     "\n",
     "async def search_url_for_entity_async(query: str):\n",
-    "    results = await serper_search_async(\n",
+    "    search_results = await serper_search_async(\n",
     "        search_term=query,\n",
     "        gl=gl,\n",
     "        hl=hl,\n",
     "        num=k,\n",
     "        tbs=tbs,\n",
-    "        search_type=search_type,\n",
+    "        search_type=\"search\",\n",
     "    )\n",
-    "    return extract_entity_url_and_image(results)"
+    "\n",
+    "    image_results = None if \"definition\" in query else await serper_search_async(\n",
+    "            search_term=query,\n",
+    "            gl=gl,\n",
+    "            hl=hl,\n",
+    "            num=k,\n",
+    "            tbs=tbs,\n",
+    "            search_type=\"images\",\n",
+    "        )\n",
+    "    \n",
+    "    return extract_entity_url_and_image(search_results, image_results)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'searchParameters': {'q': 'ChatGpt', 'gl': 'us', 'hl': 'en', 'num': 3, 'type': 'search', 'engine': 'google'}, 'knowledgeGraph': {'title': 'ChatGPT', 'type': 'Computer program', 'imageUrl': 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSE0_kvfFhLnJU0KZHDXOdED-y5VUeuVi9TmqBcKSg&s=0', 'description': 'ChatGPT is a large language model-based chatbot developed by OpenAI and launched on November 30, 2022, that enables users to refine and steer a conversation towards a desired length, format, style, level of detail, and language.', 'descriptionSource': 'Wikipedia', 'descriptionLink': 'https://en.wikipedia.org/wiki/ChatGPT', 'attributes': {'Initial release date': 'November 30, 2022', 'Developer(s)': 'OpenAI', 'Engine': 'GPT-3.5 (free and paid); GPT-4 (paid only)', 'License': 'Proprietary service', 'Platform': 'Cloud computing platforms', 'Stable release': 'November 21, 2023; 13 days ago', 'Written in': 'Python'}}, 'organic': [{'title': 'ChatGPT', 'link': 'https://chat.openai.com/', 'snippet': 'ChatGPT is a free-to-use AI system. Use it for engaging conversations, gain insights, automate tasks, and witness the future of AI, all in one place.', 'position': 1}, {'title': 'Introducing ChatGPT - OpenAI', 'link': 'https://openai.com/blog/chatgpt', 'snippet': 'ChatGPT is a sibling model to InstructGPT, which is trained to follow an instruction in a prompt and provide a detailed response.', 'date': 'Nov 30, 2022', 'position': 2}, {'title': 'OpenAI', 'link': 'https://openai.com/', 'snippet': 'DALL·E 3 is now available in ChatGPT Plus and Enterprise. Oct 19, 2023October 19, 2023 · ChatGPT Can Now See Hear And Speak. ChatGPT can now see, hear, and ...', 'position': 3}], 'relatedSearches': [{'query': 'How to use ChatGPT'}, {'query': 'ChatGPT login with Google'}, {'query': 'ChatGPT free online'}, {'query': 'OpenAI login'}, {'query': 'chat.openai.com login'}, {'query': 'ChatGPT alternative'}, {'query': 'Chat GPT login free'}, {'query': 'Auto ChatGPT'}]}\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "{'url': 'https://openai.com/',\n",
-       " 'imageUrl': 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSE0_kvfFhLnJU0KZHDXOdED-y5VUeuVi9TmqBcKSg&s=0'}"
+       "{'url': 'https://en.wikipedia.org/wiki/ChatGPT',\n",
+       " 'image_url': 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1200px-ChatGPT_logo.svg.png'}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -431,56 +473,105 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "In the realm of artificial intelligence and big data, several key players stand out with their innovative contributions. Hugging Fase, a leader in machine learning models. Another major entity, OpenYI, has revolutionized language models. We now have the largest LLMs ever such as the Falkon LLM model\n",
+      " And sometimes they're in a network. So you imagine them connected with network links and a dynamic network, those can change, right? So I was talking to you, but now I can't talk to you anymore. Now I'm connected to a person over here. It's a really hard environment mathematically speaking. And there's a lot of really strong lower bounds, which you could imagine if the network can change all the time and a bad guy is doing it, it's like hard to do things well., So there's an algorithm running on every single node in the network. Yeah. And then you're trying to say something of any kind that makes any kind of definitive sense about the performance of that algorithm. Yeah, so I just submitted a new paper on this a couple of weeks ago. And we were looking at a very simple problem. There's some messages in the network. We want everyone to get them. If the network doesn't change,, you can do this pretty well. You can pipeline them. There's some basic algorithms that work really well. If the network can change every round, there's these lower bounds that says, it takes a really long time. There's a way that no matter what algorithm you come up with, there's a way the network can change in such a way that just really slows down your progress basically, right? So smooth analysis there says, yeah, but that seems like you'd have really bad luck, if your network was changing exactly in the right way that you needed to screw your algorithm. So we said, what if we randomly just add or remove a couple of edges in every round? So the adversary is trying to choose the worst possible network. And we're just tweaking it a little bit. And in that case, this is a new paper. I mean, it's a blinded submission, so maybe I shouldn't, it's not, whatever. We basically showed., An anonymous friend of yours submitted a paper. An anonymous friend of mine, yeah, whose paper should be accepted. Showed that even just adding like one random edge per round, and here's the cool thing about it, the simplest possible solution to this problem blows away that lower bound and does really well. So that's like a very fragile lower bound because we're like, it's almost impossible\n",
+      " to actually keep things slow. I wonder how many lower bounds you can smash open with this kind of analysis and show that they're fragile. It's my interest, yeah. Because in distributed algorithms, there's a ton of really famous strong lower bounds, but things have to go wrong, really, really wrong for these lower bound arguments to work.\n",
       "```json\n",
       "{\n",
       "  \"entities\": [\n",
       "    {\n",
-      "      \"name\": \"Hugging Face\",\n",
-      "      \"definition\": \"AI company specializing in NLP models\",\n",
-      "      \"ekg_search_keyword\": \"Hugging Face\"\n",
+      "      \"name\": \"dynamic network\",\n",
+      "      \"definition\": \"Network whose connections change over time\",\n",
+      "      \"search_keyword\": \"dynamic network + computer science\"\n",
       "    },\n",
       "    {\n",
-      "      \"name\": \"OpenAI\",\n",
-      "      \"definition\": \"AI research lab, created GPT models\",\n",
-      "      \"ekg_search_keyword\": \"OpenAI\"\n",
+      "      \"name\": \"lower bounds\",\n",
+      "      \"definition\": \"Minimum performance measure in algorithms\",\n",
+      "      \"search_keyword\": \"lower bounds + algorithms\"\n",
       "    },\n",
       "    {\n",
-      "      \"name\": \"Falcon LLM model\",\n",
-      "      \"definition\": \"Large language model for AI applications\",\n",
-      "      \"ekg_search_keyword\": \"Falcon LLM model\"\n",
+      "      \"name\": \"smooth analysis\",\n",
+      "      \"definition\": \"Framework for analyzing algorithms' performance\",\n",
+      "      \"search_keyword\": \"smooth analysis + algorithms\"\n",
       "    }\n",
       "  ]\n",
       "}\n",
       "```\n",
-      "proactive_rare_word_agent_response entities=[Entity(name='Hugging Face', definition='AI company specializing in NLP models', ekg_search_keyword='Hugging Face'), Entity(name='OpenAI', definition='AI research lab, created GPT models', ekg_search_keyword='OpenAI'), Entity(name='Falcon LLM model', definition='Large language model for AI applications', ekg_search_keyword='Falcon LLM model')]\n",
-      "entities=[Entity(name='Hugging Face', definition='AI company specializing in NLP models', ekg_search_keyword='Hugging Face'), Entity(name='OpenAI', definition='AI research lab, created GPT models', ekg_search_keyword='OpenAI'), Entity(name='Falcon LLM model', definition='Large language model for AI applications', ekg_search_keyword='Falcon LLM model')]\n",
-      "Hugging Face\n",
-      "{'url': 'https://github.com/huggingface', 'imageUrl': 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQe95xXWC9oVNc8Kss7TwKOWq5d4-Zg2s_kMxYrBVfMqOKAPR3DZfRCWX4&s=0'}\n",
-      "OpenAI\n",
-      "{'url': 'https://en.wikipedia.org/wiki/OpenAI', 'imageUrl': 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT8pfsL6cbfea_zrYx9SMix7ckz4aRhubZuHIXLmMSmvfDIZXxYAr6Bj88&s=0'}\n",
-      "Falcon LLM model\n",
-      "{'url': 'https://falconllm.tii.ae/'}\n"
+      "proactive_rare_word_agent_response entities=[Entity(name='dynamic network', definition='Network whose connections change over time', search_keyword='dynamic network + computer science'), Entity(name='lower bounds', definition='Minimum performance measure in algorithms', search_keyword='lower bounds + algorithms'), Entity(name='smooth analysis', definition=\"Framework for analyzing algorithms' performance\", search_keyword='smooth analysis + algorithms')]\n",
+      "entities=[Entity(name='dynamic network', definition='Network whose connections change over time', search_keyword='dynamic network + computer science'), Entity(name='lower bounds', definition='Minimum performance measure in algorithms', search_keyword='lower bounds + algorithms'), Entity(name='smooth analysis', definition=\"Framework for analyzing algorithms' performance\", search_keyword='smooth analysis + algorithms')]\n",
+      "dynamic network + computer science\n",
+      "{'url': 'https://www.sciencedirect.com/topics/computer-science/dynamic-network', 'image_url': 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/DynamicNetworkAnalysisExample.jpg/340px-DynamicNetworkAnalysisExample.jpg'}\n",
+      "lower bounds + algorithms\n",
+      "{'url': 'https://www.geeksforgeeks.org/lower-and-upper-bound-theory/', 'image_url': 'https://i.ytimg.com/vi/PNPKUcX940o/maxresdefault.jpg'}\n",
+      "smooth analysis + algorithms\n",
+      "{'url': 'https://en.wikipedia.org/wiki/Smoothed_analysis', 'image_url': 'https://i.ytimg.com/vi/nRnn96xf_MI/hqdefault.jpg'}\n"
      ]
     }
    ],
    "source": [
-    "test_transcript = \"\"\"\n",
-    "In the realm of artificial intelligence and big data, several key players stand out with their innovative contributions. Hugging Fase, a leader in machine learning models. Another major entity, OpenYI, has revolutionized language models. We now have the largest LLMs ever such as the Falkon LLM model\"\"\"\n",
+    "test_transcript = generate_test_input()\n",
     "print(test_transcript)\n",
     "res = run_proactive_rare_word_agent_and_definer(test_transcript, [])\n",
     "print(res)\n",
     "for entities in res.entities:\n",
-    "    print(entities.name)\n",
-    "    print(await search_url_for_entity_async(entities.name))"
+    "    print(entities.search_keyword)\n",
+    "    print(await search_url_for_entity_async(entities.search_keyword))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Just go for the best intuitive way that works the best\n",
+    "\n",
+    "Pipeline\n",
+    "1. Check if page can be embed\n",
+    "2. Check if url is accurate for definition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check if page can be embedded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The page can be embedded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "\n",
+    "# URL of the page you want to check\n",
+    "url = 'https://www.labellerr.com/blog/what-are-adversarial-attacks-in-machine-learning-and-how-can-you-prevent-them/'\n",
+    "\n",
+    "# Send a request to the URL\n",
+    "response = requests.head(url)\n",
+    "\n",
+    "# Check the headers for 'X-Frame-Options' or 'Content-Security-Policy'\n",
+    "x_frame_options = response.headers.get('X-Frame-Options')\n",
+    "csp = response.headers.get('Content-Security-Policy')\n",
+    "\n",
+    "if x_frame_options or ('frame-ancestors' in csp if csp else False):\n",
+    "    print(\"The page cannot be embedded.\")\n",
+    "else:\n",
+    "    print(\"The page can be embedded.\")\n"
    ]
   },
   {

--- a/server/tests/experiment-definer.ipynb
+++ b/server/tests/experiment-definer.ipynb
@@ -27,32 +27,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Processing episode_069_large...\n",
-      "Processing episode_305_large...\n",
-      "Processing episode_166_large...\n",
-      "Processing episode_023_large...\n",
-      "Processing episode_095_large...\n",
-      "Processing episode_238_large...\n",
-      "Processing episode_058_large...\n",
-      "Processing episode_239_large...\n",
-      "Processing episode_253_large...\n",
-      "Processing episode_006_large...\n"
+      "Processing episode_246_large...\n",
+      "Processing episode_277_large...\n",
+      "Processing episode_094_large...\n",
+      "Processing episode_195_large...\n",
+      "Processing episode_006_large...\n",
+      "Processing episode_007_large...\n",
+      "Processing episode_308_large...\n",
+      "Processing episode_099_large...\n",
+      "Processing episode_113_large...\n",
+      "Processing episode_004_large...\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "\" The art of running such a lab is that there are strategic priorities for the company. And there are areas where we do want to invest and pressing problems. And so it's a little bit of a trickle down and filter up meets in the middle. And so you don't tell people you have to do X, but you say X would be particularly appreciated this year. And then people reinterpret, X through the filter of things they want to do and they're interested in. And miraculously, it usually comes together very well. One thing that really helps is Adobe has a really broad portfolio of products. So if we have a good idea, there's usually a product team that is intrigued or interested. So it means we don't have to qualify things too much ahead of time., Once in a while, the product teams sponsor extra intern, because they have a particular problem that they really care about, in which case it's a little bit more, we really need one of these. And then we sort of say, great, I get an extra intern, we find an intern who thinks that's a great problem. But that's not the typical model. That's sort of the icing on the cake as far as the budget is concerned. And all of the above end up being important. It's really hard to predict, at the beginning of the summer, which we all have high hopes of all of the intern projects, but ultimately, some of them pay off and some of them sort of are a nice paper, but don't turn into a feature. Others turn out not to be as novel as we thought, but they'd be a great feature, but not a paper. And then others, we make a little bit of progress and we realize how much we don't know. And maybe we revisit that problem several years in a row until it,, finally we have a breakthrough and then it becomes more on track to impact a product. Jumping back to a big overall view of Adobe research, what are you looking forward to in 2019 and beyond? What is, you mentioned there's a giant suite of products, a giant suite of ideas, new interns, a large team of researchers.\\n What do you think the future holds? In terms of the technological breakthroughs? Technological breakthroughs, especially ones that will make it into product, will get to impact the world. So I think the creative or the analytics assistants that we talked about where they're constantly trying to figure out what you're trying to do and how can they be helpful and make useful suggestions is a really hot topic. And it's very unpredictable as to when\""
+       "\" And if you tell yourself, hey, deadlines make me sharp, pressure makes me sharp, you will perform better. So stress and anxiety, what is that? And can it be leveraged for good? Absolutely, look, whether or not you get into a cold ice bath, or a hot sauna so hot you want to get out, or you get hit square in the face with something over text that you really didn't want to hear or see, it's adrenaline. It's just adrenaline. And so your subjective readout of that and what it means is really important., And you can just channel that. Well, you can, if you agree with the following statement, which I do, and many people do because the data support it, which is Allie Crum's statement, not mine, which is she directs the mind body lab at Stanford. She's brilliant, by the way, brilliant Harvard trained, Yale trained, trained licensed clinical psychologist,, also a tenured professor at Stanford. She's a Olympian, no, excuse me, a division one athlete in gymnastics and martial arts. And her dad is a long time martial arts trainer, who's done work with special forces and he's an amazing human being and very humble, very kind, lovely woman and professor scientist., She says, anything that you do and experience, but especially stress is the consequence of that thing and what you believe about that thing. And so if you consume a lot of information about the powers of stressful states to bring out your best,\\n you will perform better. If you consume a lot of information about the power of stress to cripple you, you will perform worse. There's absolutely no question, the data are striking. And this is not growth mindset. This is just simply what do you believe about stress\""
       ]
      },
-     "execution_count": 2,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -63,7 +63,7 @@
     "\n",
     "import test_on_lex\n",
     "\n",
-    "transcripts = test_on_lex.load_lex_transcripts(random_n=10, transcript_folder=\"./lex_whisper_transcripts/\", chunk_time_seconds=20)\n",
+    "transcripts = test_on_lex.load_lex_transcripts(random_n=10, transcript_folder=\"./lex_whisper_transcripts/\", chunk_time_seconds=15)\n",
     "\n",
     "import random\n",
     "def generate_test_input():\n",
@@ -90,19 +90,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
     "proactive_rare_word_agent_prompt_blueprint = \"\"\"\n",
     "# Objective\n",
-    "Your role is to identify and define \"Rare Entities\" in a conversation transcript. Types of \"Rare Entities\" include rare words, phrases, jargons, adages, people, places, organizations, events etc that are not well known to the average high schooler, in accordance to current trends. You can also intelligently detect entities that are described in the conversation but not explicitly mentioned.\n",
+    "Your role is to identify and define \"Rare Entities\" in a conversation transcript. Types of \"Rare Entities\" include rare words, jargons, adages, concepts, people, places, organizations, events etc that are not well known to the average high schooler, in accordance to current trends. You can also intelligently detect entities that are described in the conversation but not explicitly mentioned.\n",
     "\n",
     "# Criteria for Rare Entities in order of importance\n",
     "1. Rarity: Select entities that are unlikely for an average high schooler to know. Well known entities are like Fortune 500 organizations, worldwide-known events, popular locations, and entities popularized by recent news or events such as \"COVID-19\", \"Bitcoin\", or \"Generative AI\".\n",
     "2. Utility: Definition should help a user understand the conversation better and achieve their goals.\n",
     "3. No Redundancy: Exclude definitions if already defined in the conversation.\n",
-    "4. Complexity: Choose terms with non-obvious meanings, such as \"Butterfly Effect\" but not \"Electric Car\".\n",
+    "4. Complexity: Choose phrases with non-obvious meanings, such that their meaning cannot be derived from simple words within the entity name, such as \"Butterfly Effect\" which has a totally different meaning from its base words, but not \"Electric Car\" nor \"Lane Keeping System\" as they're easily derived.\n",
     "5. Definability: Must be clearly and succinctly definable in under 10 words.\n",
     "6. Existance: Don't select entities if you have no knowledge of them\n",
     "\n",
@@ -118,12 +118,14 @@
     "- it's OK to output an empty array - most of the time, the array will be empty, only include items if the fit all the requirements\n",
     "\n",
     "## Additional Guidelines:\n",
+    "- Only select nouns, not verbs or adjectives.\n",
+    "- Select entities iff they have an entry in an encyclopedia, wikipedia, dictionary, or other reference material.\n",
     "- Do not define entities you yourself are not familiar with, you can try to piece together the implied entity, but if you are not 90% confident, skip it.\n",
     "- For the search keyword, use complete, official and context relevant keyword(s) to search for that entity. You might need to autocomplete entity names or use their official names or add additional context keywords (like the type of entity) to help with searchability, especially if the entity is ambiguous or has multiple meanings. Additionally, for rare words, add \"definition\" to the search keyword.\n",
     "- Definitions should use simple language to be easily understood.\n",
     "- Select entities whose definitions you are very confident about, otherwise skip them.\n",
     "- Multiple entities can be detected from one phrase, for example, \"The Lugubrious Game\" can be defined as a painting (iff the entire term \"the lugubrious game\" is mentioned), and the rare word \"lugubrious\" is also worth defining.\n",
-    "- Limit results to {number_of_definitions} entities, prioritize rarity.\n",
+    "- Limit results to {number_of_definitions} entities, prioritize rarity and utility.\n",
     "- Examples:\n",
     "    - Completing incomplete name example: If the conversation talks about \"Balmer\" and \"Microsoft\", the keyword is \"Steve Balmer + person\", and the name would be \"Steve Balmer\" because it is complete.\n",
     "    - Replacing unofficial name example: If the conversation talks about \"Clay Institute\", the keyword is \"Clay Mathematics Institute + organization\" since that is the official name, but the entity name would be \"Clay Institute\" because that is the name quoted from the conversation.\n",
@@ -144,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +404,7 @@
     "    x_frame_options = response.headers.get('X-Frame-Options')\n",
     "    csp = response.headers.get('Content-Security-Policy')\n",
     "\n",
-    "    return x_frame_options or ('frame-ancestors' in csp if csp else False)\n",
+    "    return not (x_frame_options or ('frame-ancestors' in csp if csp else False))\n",
     "\n",
     "def extract_entity_url_and_image(search_results: dict, image_results: dict):\n",
     "    # Only get the first top url and image_url\n",
@@ -429,32 +431,52 @@
     "    return res\n",
     "\n",
     "async def search_url_for_entity_async(query: str):\n",
-    "    search_results = await serper_search_async(\n",
-    "        search_term=query,\n",
-    "        gl=gl,\n",
-    "        hl=hl,\n",
-    "        num=k,\n",
-    "        tbs=tbs,\n",
-    "        search_type=\"search\",\n",
-    "    )\n",
+    "    async def inner_search(query:str): \n",
+    "        search_task = asyncio.create_task(serper_search_async(\n",
+    "            search_term=query,\n",
+    "            gl=gl,\n",
+    "            hl=hl,\n",
+    "            num=k,\n",
+    "            tbs=tbs,\n",
+    "            search_type=\"search\",\n",
+    "        ))\n",
     "\n",
-    "    image_results = None if \"definition\" in query else await serper_search_async(\n",
+    "        image_search_task = None if \"definition\" in query else asyncio.create_task(serper_search_async(\n",
     "            search_term=query,\n",
     "            gl=gl,\n",
     "            hl=hl,\n",
     "            num=k,\n",
     "            tbs=tbs,\n",
     "            search_type=\"images\",\n",
-    "        )\n",
+    "        ))\n",
+    "\n",
+    "        tasks = [search_task]\n",
+    "        if image_search_task:\n",
+    "            tasks.append(image_search_task)\n",
+    "\n",
+    "        search_results, image_results = await asyncio.gather(*tasks)\n",
+    "        \n",
+    "        return extract_entity_url_and_image(search_results, image_results)\n",
     "    \n",
-    "    return extract_entity_url_and_image(search_results, image_results)"
+    "    res = await inner_search(query)\n",
+    "    print(res)\n",
+    "    if \"url\" not in res:\n",
+    "        res = await inner_search(query + \" wiki\") # fallback search using wiki\n",
+    "    return res"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'image_url': 'https://miro.medium.com/v2/resize:fit:1400/1*uxbmkTqj4E_FauCo7WV0nw.jpeg'}\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -462,55 +484,52 @@
        " 'image_url': 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1200px-ChatGPT_logo.svg.png'}"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "await search_url_for_entity_async(\"ChatGpt\")"
+    "await search_url_for_entity_async(\"how is chatgpt doing medium\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " And sometimes they're in a network. So you imagine them connected with network links and a dynamic network, those can change, right? So I was talking to you, but now I can't talk to you anymore. Now I'm connected to a person over here. It's a really hard environment mathematically speaking. And there's a lot of really strong lower bounds, which you could imagine if the network can change all the time and a bad guy is doing it, it's like hard to do things well., So there's an algorithm running on every single node in the network. Yeah. And then you're trying to say something of any kind that makes any kind of definitive sense about the performance of that algorithm. Yeah, so I just submitted a new paper on this a couple of weeks ago. And we were looking at a very simple problem. There's some messages in the network. We want everyone to get them. If the network doesn't change,, you can do this pretty well. You can pipeline them. There's some basic algorithms that work really well. If the network can change every round, there's these lower bounds that says, it takes a really long time. There's a way that no matter what algorithm you come up with, there's a way the network can change in such a way that just really slows down your progress basically, right? So smooth analysis there says, yeah, but that seems like you'd have really bad luck, if your network was changing exactly in the right way that you needed to screw your algorithm. So we said, what if we randomly just add or remove a couple of edges in every round? So the adversary is trying to choose the worst possible network. And we're just tweaking it a little bit. And in that case, this is a new paper. I mean, it's a blinded submission, so maybe I shouldn't, it's not, whatever. We basically showed., An anonymous friend of yours submitted a paper. An anonymous friend of mine, yeah, whose paper should be accepted. Showed that even just adding like one random edge per round, and here's the cool thing about it, the simplest possible solution to this problem blows away that lower bound and does really well. So that's like a very fragile lower bound because we're like, it's almost impossible\n",
-      " to actually keep things slow. I wonder how many lower bounds you can smash open with this kind of analysis and show that they're fragile. It's my interest, yeah. Because in distributed algorithms, there's a ton of really famous strong lower bounds, but things have to go wrong, really, really wrong for these lower bound arguments to work.\n",
+      " and stoop and build them up with worn out tools, if you can make one heap of all your winnings and risk it all on one turn of pitch and toss and lose and start again at your beginnings and never breathe a word about your loss,, if you can force your heart to nerve and sinew to serve your turn long after they're gone and so hold on when there's nothing in you except the will which says to them, hold on. If you can talk with crowds and keep your virtue,, I like this one, and walk with kings nor lose the common touch, if neither foes nor loving friends can hurt you, if all men count with you but none too much, if you can fill the unforgiving minute with 60 seconds worth of distance run,, yours is the earth and everything that's in it and which is more, you'll be a man, my son. Thank you, Andrew, thank you, thank you, Mike, for the knife, it's a, I don't know. It's an important poem. And engraved in it, yeah, it's yours. Yours is the earth and everything that's in it., We toiled over what to engrave, and then finally I just said, Mike, just pick something that speaks to you, you're the craftsman, and so he selected that. There's certain ways to pull yourself in that book. Actually, Karl Deisseroth, he wrote the book Projections.\n",
+      " One of my favorite, first of all, just as you said, incredible writer. Just, I mean, if you wrote fiction, if you wrote those kinds of things, I'm curious to see where he goes with his writing. It's very interesting. I think that book took him 10 years to write,\n",
       "```json\n",
       "{\n",
       "  \"entities\": [\n",
       "    {\n",
-      "      \"name\": \"dynamic network\",\n",
-      "      \"definition\": \"Network whose connections change over time\",\n",
-      "      \"search_keyword\": \"dynamic network + computer science\"\n",
+      "      \"name\": \"pitch and toss\",\n",
+      "      \"definition\": \"A simple gambling game with coins\",\n",
+      "      \"search_keyword\": \"pitch and toss + game\"\n",
       "    },\n",
       "    {\n",
-      "      \"name\": \"lower bounds\",\n",
-      "      \"definition\": \"Minimum performance measure in algorithms\",\n",
-      "      \"search_keyword\": \"lower bounds + algorithms\"\n",
+      "      \"name\": \"Karl Deisseroth\",\n",
+      "      \"definition\": \"Neuroscientist and author of 'Projections'\",\n",
+      "      \"search_keyword\": \"Karl Deisseroth + person\"\n",
       "    },\n",
       "    {\n",
-      "      \"name\": \"smooth analysis\",\n",
-      "      \"definition\": \"Framework for analyzing algorithms' performance\",\n",
-      "      \"search_keyword\": \"smooth analysis + algorithms\"\n",
+      "      \"name\": \"Projections\",\n",
+      "      \"definition\": \"Book by neuroscientist Karl Deisseroth\",\n",
+      "      \"search_keyword\": \"Projections Karl Deisseroth + book\"\n",
       "    }\n",
       "  ]\n",
       "}\n",
       "```\n",
-      "proactive_rare_word_agent_response entities=[Entity(name='dynamic network', definition='Network whose connections change over time', search_keyword='dynamic network + computer science'), Entity(name='lower bounds', definition='Minimum performance measure in algorithms', search_keyword='lower bounds + algorithms'), Entity(name='smooth analysis', definition=\"Framework for analyzing algorithms' performance\", search_keyword='smooth analysis + algorithms')]\n",
-      "entities=[Entity(name='dynamic network', definition='Network whose connections change over time', search_keyword='dynamic network + computer science'), Entity(name='lower bounds', definition='Minimum performance measure in algorithms', search_keyword='lower bounds + algorithms'), Entity(name='smooth analysis', definition=\"Framework for analyzing algorithms' performance\", search_keyword='smooth analysis + algorithms')]\n",
-      "dynamic network + computer science\n",
-      "{'url': 'https://www.sciencedirect.com/topics/computer-science/dynamic-network', 'image_url': 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/DynamicNetworkAnalysisExample.jpg/340px-DynamicNetworkAnalysisExample.jpg'}\n",
-      "lower bounds + algorithms\n",
-      "{'url': 'https://www.geeksforgeeks.org/lower-and-upper-bound-theory/', 'image_url': 'https://i.ytimg.com/vi/PNPKUcX940o/maxresdefault.jpg'}\n",
-      "smooth analysis + algorithms\n",
-      "{'url': 'https://en.wikipedia.org/wiki/Smoothed_analysis', 'image_url': 'https://i.ytimg.com/vi/nRnn96xf_MI/hqdefault.jpg'}\n"
+      "proactive_rare_word_agent_response entities=[Entity(name='pitch and toss', definition='A simple gambling game with coins', search_keyword='pitch and toss + game'), Entity(name='Karl Deisseroth', definition=\"Neuroscientist and author of 'Projections'\", search_keyword='Karl Deisseroth + person'), Entity(name='Projections', definition='Book by neuroscientist Karl Deisseroth', search_keyword='Projections Karl Deisseroth + book')]\n",
+      "entities=[Entity(name='pitch and toss', definition='A simple gambling game with coins', search_keyword='pitch and toss + game'), Entity(name='Karl Deisseroth', definition=\"Neuroscientist and author of 'Projections'\", search_keyword='Karl Deisseroth + person'), Entity(name='Projections', definition='Book by neuroscientist Karl Deisseroth', search_keyword='Projections Karl Deisseroth + book')]\n",
+      "{'url': 'https://en.wikipedia.org/wiki/Pitching_pennies', 'image_url': 'https://content.artofmanliness.com/uploads/2021/11/boys.jpg'}\n",
+      "{'url': 'https://en.wikipedia.org/wiki/Karl_Deisseroth', 'image_url': 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Karl_Deisseroth_by_Christopher_Michel_04.jpg/800px-Karl_Deisseroth_by_Christopher_Michel_04.jpg'}\n",
+      "{'url': 'https://www.amazon.com/Projections-Story-Emotions-Karl-Deisseroth/dp/1984853694', 'image_url': 'https://images.penguinrandomhouse.com/cover/9781984853714'}\n"
      ]
     }
    ],
@@ -520,8 +539,10 @@
     "res = run_proactive_rare_word_agent_and_definer(test_transcript, [])\n",
     "print(res)\n",
     "for entities in res.entities:\n",
-    "    print(entities.search_keyword)\n",
-    "    print(await search_url_for_entity_async(entities.search_keyword))"
+    "    res = await search_url_for_entity_async(entities.search_keyword)\n",
+    "    if \"url\" not in res:\n",
+    "        res = await search_url_for_entity_async(entities.search_keyword + \" wiki\")\n",
+    "    print(res)"
    ]
   },
   {
@@ -544,7 +565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -559,7 +580,7 @@
     "import requests\n",
     "\n",
     "# URL of the page you want to check\n",
-    "url = 'https://www.labellerr.com/blog/what-are-adversarial-attacks-in-machine-learning-and-how-can-you-prevent-them/'\n",
+    "url = 'https://en.wikipedia.org/wiki/Borat_Sagdiyev'\n",
     "\n",
     "# Send a request to the URL\n",
     "response = requests.head(url)\n",


### PR DESCRIPTION
### Changelog
- Changed definer prompt to focus on "Nouns" and generalize "contextual keywords"
- Improved images with an individual image search for each rare entity
- Improve ref url to only use embeddable pages

#### Improved images
<img width="616" alt="image" src="https://github.com/TeamOpenSmartGlasses/Convoscope/assets/56083944/1d344990-5a15-41ee-9aa5-46c55f9c0c2b">

very relevant images now

![image](https://github.com/TeamOpenSmartGlasses/Convoscope/assets/56083944/864b6565-1fc4-4f90-b9c3-1226ffa00f34)
![image](https://github.com/TeamOpenSmartGlasses/Convoscope/assets/56083944/92b03637-6dc0-4604-8881-872010ffcad3)

#### Other examples
![image](https://github.com/TeamOpenSmartGlasses/Convoscope/assets/56083944/f8b9ce07-832c-4ff4-aaa4-31fa166ef997)
![image](https://github.com/TeamOpenSmartGlasses/Convoscope/assets/56083944/b1d0b208-ff7f-43fe-81e8-ef5758e30d13)

#### Fallback
I also added this thing where if a search comes up with no embeddable pages, we fallback to wiki, its very useful for pages that have a lot of hype news
<img width="838" alt="image" src="https://github.com/TeamOpenSmartGlasses/Convoscope/assets/56083944/7fd4608c-f261-429d-9b57-b8e1f203ebb0">
