### PR TITLE
refactor: move window vars into recoil state

### DIFF
--- a/web_frontend/src/App.tsx
+++ b/web_frontend/src/App.tsx
@@ -2,32 +2,41 @@ import { useEffect } from "react";
 import "./index.css";
 import { useTranscription } from "./hooks/useTranscription";
 import { useUiUpdateBackendPoll } from "./hooks/useUiUpdateBackendPoll";
-import { generateRandomUserId, setUserIdAndDeviceId } from "./utils/utils";
 import Cookies from "js-cookie";
 import MainLayout from "./layouts/MainLayout";
+import { useRecoilState } from "recoil";
+import { userIdState } from "./recoil";
+import { useAuth } from "./auth";
 
 export default function App() {
   useTranscription();
   useUiUpdateBackendPoll();
+  useAuth();
+
+  const [userId, setUserId] = useRecoilState(userIdState);
+  console.log(userId);
 
   useEffect(() => {
-    let search = window.location.search;
-    let params = new URLSearchParams(search);
-    let userId = params.get('userId');
+    const search = window.location.search;
+    const paramsUserId = new URLSearchParams(search).get("userId");
+    const cookiesUserId = Cookies.get("userId");
 
-    if (userId == undefined || userId == null || userId == "") {
+    if (!paramsUserId) {
       console.log("No userID in URL - checking for existing userID");
-      userId = Cookies.get("userId");
+      if (!cookiesUserId) {
+        console.log("No userID detected - generating random userID");
+      }
     }
+    const foundUserId = paramsUserId ? paramsUserId : cookiesUserId;
 
-    if (userId == undefined || userId == null || userId == "") {
-      console.log("No userID detected - generating random userID");
-      userId = generateRandomUserId();
+    if (foundUserId) {
+      console.log("userId found: " + foundUserId);
+      setUserId(foundUserId);
+      Cookies.set("userId", foundUserId, { expires: 9999 });
     } else {
-      console.log("userId found: " + userId);
+      Cookies.set("userId", userId, { expires: 9999 });
     }
-    setUserIdAndDeviceId(userId);
-  }, []);
+  }, [setUserId, userId]);
 
   return <MainLayout />;
 }

--- a/web_frontend/src/components/ReferenceCard.tsx
+++ b/web_frontend/src/components/ReferenceCard.tsx
@@ -23,6 +23,8 @@ import { useState } from "react";
 import CardWrapper, { CardWrapperProps } from "./CardWrapper";
 import axiosClient from "../axiosConfig";
 import { RATE_INSIGHT_ENDPOINT } from "../serverEndpoints";
+import { useRecoilValue } from "recoil";
+import { authTokenState } from "../recoil";
 
 const useStyles = createStyles((theme) => ({
   button: {
@@ -39,29 +41,6 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-const rateInsight = (entity: Entity, newState: ThumbState) => {
-  let rating = -1;
-  if (newState == ThumbState.UP) rating = 10;
-  if (newState == ThumbState.DOWN) rating = 0;
-  if (rating == -1) return;
-
-  const rateInsightRequestBody = {
-    "Authorization": window.authToken,
-    resultUuid: entity.uuid,
-    rating: rating,
-  };
-
-  axiosClient
-    .post(RATE_INSIGHT_ENDPOINT, rateInsightRequestBody)
-    .then((res) => {
-      if (res.data.success) {
-        console.log("Successfully rated card");
-      }
-    })
-    .catch(function (error) {
-      console.error(error);
-    });
-};
 interface ReferenceCardProps
   extends Omit<CardWrapperProps, "agentName" | "agentIconSrc"> {
   entity: Entity;
@@ -134,6 +113,31 @@ enum ThumbState {
 const ThumbButtons = ({ entity }: { entity: Entity }) => {
   const { classes } = useStyles();
   const [thumbState, setThumbState] = useState<ThumbState>();
+  const authToken = useRecoilValue(authTokenState);
+
+  const rateInsight = (entity: Entity, newState: ThumbState) => {
+    let rating = -1;
+    if (newState == ThumbState.UP) rating = 10;
+    if (newState == ThumbState.DOWN) rating = 0;
+    if (rating == -1) return;
+
+    const rateInsightRequestBody = {
+      Authorization: authToken,
+      resultUuid: entity.uuid,
+      rating: rating,
+    };
+
+    axiosClient
+      .post(RATE_INSIGHT_ENDPOINT, rateInsightRequestBody)
+      .then((res) => {
+        if (res.data.success) {
+          console.log("Successfully rated card");
+        }
+      })
+      .catch(function (error) {
+        console.error(error);
+      });
+  };
 
   return (
     <Group noWrap pl="xs" pb="xs">

--- a/web_frontend/src/components/SettingsModal.tsx
+++ b/web_frontend/src/components/SettingsModal.tsx
@@ -1,20 +1,20 @@
 import {
   Alert,
   Button,
-  Group,
   // Divider,
   // FileButton,
   Modal,
   Stack,
   Text,
-  TextInput,
   createStyles,
   // Title,
 } from "@mantine/core";
 import { IconInfoCircle } from "@tabler/icons-react";
 import Cookies from "js-cookie";
 import { useRef, useState } from "react";
-import * as authn from "../auth";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { authTokenState, userIdState } from "../recoil";
+import { useSignInWithGoogle } from "../auth";
 // import axiosClient from "../axiosConfig";
 // import { UPLOAD_USERDATA_ENDPOINT } from "../serverEndpoints";
 
@@ -22,30 +22,26 @@ interface SettingsModalProps {
   smallerThanMedium: boolean;
   opened: boolean;
   closeSettings: () => void;
-  setUserIdAndDeviceId: (newUserId: string) => void;
 }
 
 const useStyles = createStyles((theme) => ({
   header: {
     backgroundColor: theme.colors.cardFill,
   },
- 
+
   content: {
     backgroundColor: theme.colors.cardFill,
-    border: `1px solid ${theme.colors.cardStroke}`
-  }
+    border: `1px solid ${theme.colors.cardStroke}`,
+  },
 }));
 
 const SettingsModal = ({
   smallerThanMedium,
   opened,
   closeSettings,
-  setUserIdAndDeviceId,
 }: SettingsModalProps) => {
-  const {classes} = useStyles();
-  const [userId, setUserId] = useState<string | undefined>(
-    Cookies.get("userId")
-  );
+  const { classes } = useStyles();
+  const [userId, setUserId] = useRecoilState(userIdState);
   const [isCustomUser, setIsCustomUser] = useState<boolean | undefined>(
     Cookies.get("isCustomUser") === "true"
   );
@@ -55,11 +51,13 @@ const SettingsModal = ({
   const updateUsername = () => {
     if (ref.current?.value && ref.current.value !== "") {
       Cookies.set("isCustomUser", "true", { expires: 9999 });
-      setUserIdAndDeviceId(ref.current?.value);
       setIsCustomUser(true);
       setUserId(ref.current.value);
     }
   };
+
+  const authToken = useRecoilValue(authTokenState);
+  const { signInWithGoogle } = useSignInWithGoogle();
 
   // const submitCustomData = () => {
   //   if (!file || !userId) {
@@ -97,18 +95,21 @@ const SettingsModal = ({
       classNames={{ content: classes.content, header: classes.header }}
     >
       <Stack>
-        <Alert icon={<IconInfoCircle />} title="Connect your custom data!" variant="light" color="blue">
+        <Alert
+          icon={<IconInfoCircle />}
+          title="Connect your custom data!"
+          variant="light"
+          color="blue"
+        >
           Get started by setting a custom and unique username, then upload your
           CSV file containing your entity definitions
         </Alert>
 
-        {window.authToken ? (
-          <Text>
-            Logged in
-          </Text>
+        {authToken ? (
+          <Text>Logged in</Text>
         ) : (
-          <Button onClick={authn.signInWithGoogle} variant="default" mt="auto">
-          Log in
+          <Button onClick={signInWithGoogle} variant="default" mt="auto">
+            Log in
           </Button>
         )}
 

--- a/web_frontend/src/hooks/useTranscription.ts
+++ b/web_frontend/src/hooks/useTranscription.ts
@@ -4,7 +4,11 @@ import SpeechRecognition, {
 import axiosClient from "../axiosConfig";
 import { CHAT_ENDPOINT } from "../serverEndpoints";
 import { useRecoilValue, useSetRecoilState } from "recoil";
-import { isExplicitListeningState, isRecognizingState } from "../recoil";
+import {
+  authTokenState,
+  isExplicitListeningState,
+  isRecognizingState,
+} from "../recoil";
 import { debounce } from "lodash";
 import { useCallback, useEffect, useState, useRef } from "react";
 
@@ -20,6 +24,7 @@ const debouncedSubmit = debounce((submitFunc, transcriptRef) => {
 export const useTranscription = () => {
   const isRecognizing = useRecoilValue(isRecognizingState);
   const setIsExplicitListening = useSetRecoilState(isExplicitListeningState);
+  const authToken = useRecoilValue(authTokenState);
 
   const [transcriptStartIdx, setTranscriptStartIdx] = useState(0);
 
@@ -54,7 +59,7 @@ export const useTranscription = () => {
       const text = transcript.substring(transcriptStartIdx);
 
       const payload = {
-        "Authorization": window.authToken,
+        Authorization: authToken,
         text: text,
         timestamp: Date.now(),
         isFinal,
@@ -77,7 +82,7 @@ export const useTranscription = () => {
           console.error(error);
         });
     },
-    [setTranscriptStartIdx, transcript, transcriptStartIdx]
+    [authToken, transcript, transcriptStartIdx]
   );
 
   useEffect(() => {
@@ -86,5 +91,4 @@ export const useTranscription = () => {
     // Call the debounced function with the ref
     debouncedSubmit(submitTranscript, transcriptRef);
   }, [transcript]);
-
 };

--- a/web_frontend/src/layouts/MainLayout.tsx
+++ b/web_frontend/src/layouts/MainLayout.tsx
@@ -30,7 +30,6 @@ import {
 } from "../recoil";
 import { useDisclosure, useMediaQuery } from "@mantine/hooks";
 import { useState } from "react";
-import { setUserIdAndDeviceId } from "../utils/utils";
 import CardScrollArea from "../components/CardScrollArea";
 
 // animate-able components for framer-motion
@@ -155,7 +154,6 @@ const MainLayout = () => {
         smallerThanMedium={smallerThanMedium}
         opened={opened}
         closeSettings={closeSettings}
-        setUserIdAndDeviceId={setUserIdAndDeviceId}
       />
     </>
   );

--- a/web_frontend/src/recoil.ts
+++ b/web_frontend/src/recoil.ts
@@ -1,5 +1,6 @@
 import { atom, selector } from "recoil";
 import { Entity, Insight } from "./types";
+import { generateRandomUserId } from "./utils/utils";
 
 export const isExplicitListeningState = atom<boolean>({
   key: "isExplicitListening",
@@ -51,4 +52,19 @@ export const showExplorePaneValue = selector<boolean>({
   get: ({ get }) => {
     return get(explorePaneUrlValue) !== undefined;
   },
+});
+
+export const userIdState = atom<string>({
+  key: "userId",
+  default: generateRandomUserId(),
+});
+
+export const deviceIdState = atom<string>({
+  key: "deviceId",
+  default: "CSEWebFrontendDefault",
+});
+
+export const authTokenState = atom<string | undefined>({
+  key: "authToken",
+  default: undefined,
 });

--- a/web_frontend/src/utils/utils.ts
+++ b/web_frontend/src/utils/utils.ts
@@ -1,5 +1,3 @@
-import Cookies from "js-cookie";
-
 export const generateRandomUserId = () => {
   const rand = "x"
     .repeat(5)
@@ -12,14 +10,3 @@ export const generateRandomUserId = () => {
     );
   return "WebFrontend_" + rand;
 };
-
-export const setUserIdAndDeviceId = (newUserId: string) => {
-  window.userId = newUserId;
-  Cookies.set("userId", newUserId, { expires: 9999 });
-  window.deviceId = "CSEWebFrontendDefault";
-};
-
-export const setAuthToken = (newAuthToken: string) => {
-  window.authToken = newAuthToken;
-  Cookies.set("authToken", newAuthToken, { expires: 9999 });
-}


### PR DESCRIPTION
This PR creates new Recoil atoms for `deviceId`, `userId`, and `authToken`, and replaces all occurrences of `window.userId`, `window.deviceId`, and `window.authToken` with the Recoil state values instead.